### PR TITLE
Update gel guidelines for Game Audio

### DIFF
--- a/docs/gel-guidelines.md
+++ b/docs/gel-guidelines.md
@@ -19,8 +19,9 @@ the game accessible.
 **GEL Icon Asset Pack** provides the icons which must be used; they may be 
 skinned but the pictorial shape and size must remain.  
 
-### In-game audio for devices 
-The ringer/silent switch (iOS) or mute (Android) on a device should not silence in-game audio. Therefore audio should play regardless of whether the device is silenced/muted. This follows guidelines from Android and iOS.
+### In-game audio for devices must respect user choice
+The ringer/silent switch (iOS) or mute (Android) on a device should silence in-game audio. Therefore audio should NOT play if the device is silenced or muted. This follows guidelines from Android and iOS platforms.
+https://developer.apple.com/ios/human-interface-guidelines/user-interaction/audio/
 
 ## Toolkit 
 


### PR DESCRIPTION
Added App audio requirements  - Game music and audio should respect the ringer switch
The current Gel guidelines are contrary to what Android and IOS platforms are recommending.
Games are not considered critical sounds (such as alarms) and the UX guidance from Apple is to respect the user's choice and silence the app.

https://developer.apple.com/ios/human-interface-guidelines/user-interaction/audio/

Silence
People switch their device to silent to avoid being interrupted by unexpected sounds, such as ringtones and incoming message sounds. They also want nonessential sounds disabled, including keyboard sounds, sound effects, game soundtracks, and other audible feedback. When the device is set to silent, only explicitly initiated sounds should occur, such as audio during media playback, alarms, and audio/video messaging.