### PR TITLE
CAPP-2232 - updated storage docs for new app storage

### DIFF
--- a/docs/data-storage.md
+++ b/docs/data-storage.md
@@ -41,37 +41,37 @@ gmi.getAllSettings().subtitles;
 Getting a local store instance:
 
 ```javascript
-const localStore = gmi.storage.localKeyValueStore.getStore();
+const store = gmi.storage.localStore.getStore();
 ```
 
 Saving data:
 
 ```javascript
-await localStore.set("key", { some: "data" });
+await store.set("key", { some: "data" });
 ```
 
 Retrieving data:
 
 ```javascript
-const localData = await localStore.get("key");
+const someData = await store.get("key");
 ```
 
 Deleting data:
 
 ```javascript
-await localStore.remove("key");
+await store.remove("key");
 ```
 
 Retrieve list of all keys for data in the store:
 
 ```javascript
-const keys = await localStore.list();
+const keys = await store.list();
 ```
 
 Delete all data in local store:
 
 ```javascript
-await gmi.storage.localKeyValueStore.removeStore();
+await gmi.storage.localStore.removeStore();
 ```
 
 ### Loading Shared Settings Data

--- a/docs/data-storage.md
+++ b/docs/data-storage.md
@@ -1,8 +1,10 @@
 # Using Local Storage
 
-## Saving data
-
 Data must be saved through the [GMI](gmi.md). This ensures all data access complies with BBC data policies.
+
+## On Web
+
+### Saving data
 
 ```javascript
 gmi.setGameData(key, value);
@@ -10,7 +12,7 @@ gmi.setGameData(key, value);
 
 Stores a JSON key-value pair that can then be retrieved with `getAllSettings()`.
 
-## Loading data
+### Loading data
 
 ```javascript
 gmi.getAllSettings();
@@ -34,9 +36,62 @@ gmi.getAllSettings().motion;
 gmi.getAllSettings().subtitles;
 ```
 
+## In apps
+
+Getting a local store instance:
+
+```javascript
+const localStore = gmi.storage.localKeyValueStore.getStore();
+```
+
+Saving data:
+
+```javascript
+await localStore.set("key", { some: "data" });
+```
+
+Retrieving data:
+
+```javascript
+const localData = await localStore.get("key");
+```
+
+Deleting data:
+
+```javascript
+await localStore.remove("key");
+```
+
+Retrieve list of all keys for data in the store:
+
+```javascript
+const keys = await localStore.list();
+```
+
+Delete all data in local store:
+
+```javascript
+await gmi.storage.localKeyValueStore.removeStore();
+```
+
+### Loading Shared Settings Data
+
+```javascript
+gmi.getAllSettings();
+```
+
+Returns a JSON object with [global settings](settings.md#global-settings) and specific game data.
+
+[Global settings](settings.md#global-settings) can be accessed like so:
+
+```javascript
+gmi.getAllSettings().audio;
+gmi.getAllSettings().motion;
+gmi.getAllSettings().subtitles;
+```
+
 [Home](../README.md)
 [Working with GMI](working-with-gmi.md)
 [API Reference](gmi.md)
 [Settings](settings.md)
 [Stats](stats.md#stats)
-[Using Local Storage/Cookies](data-storage.md#using-local-storagecookies)


### PR DESCRIPTION
[Ticket](https://jira.dev.bbc.co.uk/browse/CAPP-2232)

Add documentation on how games can store data when using the GMI with apps.